### PR TITLE
test(webbrowser): mock _webbrowser.get in test_get_returns_browser

### DIFF
--- a/tests/test_types/test_webbrowser.py
+++ b/tests/test_types/test_webbrowser.py
@@ -63,7 +63,11 @@ def test_open_new_tab_returns_poop_boolean() -> None:
 
 
 def test_get_returns_browser() -> None:
-    browser = Webbrowser.get()
+    with mock.patch(
+        "poop.types.webbrowser._webbrowser.get",
+        return_value=_webbrowser.GenericBrowser("/usr/bin/echo"),
+    ):
+        browser = Webbrowser.get()
     assert isinstance(browser, Browser)
 
 


### PR DESCRIPTION
## Summary
- Mock `_webbrowser.get` in `test_get_returns_browser` so the test no longer depends on the host environment having a working browser registered.
- Returns a `GenericBrowser("/usr/bin/echo")` so the assertion that `Webbrowser.get()` wraps the result in `Browser` is exercised deterministically.

## Test plan
- [x] `uv run pytest tests/test_types/test_webbrowser.py` — 17 passed
- [x] `uv run ruff check` / `uv run ruff format` — clean (prek pre-commit)
- [x] `uv run ty check poop/ tests/` — clean (prek pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)